### PR TITLE
Update "Get Thrust" link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -68,7 +68,7 @@
       </li>
       {% endfor %}
       -->
-      <li><a title="Download latest Thrust source code" href="https://github.com/thrust/thrust/releases/download/1.8.1/thrust-1.8.1.zip">Get Thrust</a></li>
+      <li><a title="Download latest Thrust source code" href="https://github.com/thrust/thrust/releases">Get Thrust</a></li>
 	</ul>
     
 


### PR DESCRIPTION
The link is dead, and it's probably not worth the effort to update it on every release. Just link to the page where the latest can be found.