### PR TITLE
Fix link to Doxygen docs.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,7 +43,7 @@
       <li><a title="Quick Start Guide" href="http://github.com/thrust/thrust/wiki/Quick-Start-Guide">Get Started</a></li>
       <li><a title="Thrust Documentation" href="http://github.com/thrust/thrust/wiki/Documentation" class="submenu_title">Documentation</a>
         <ul class="submenu">
-            <li><a title="Thrust API Doxygen" href="http://thrust.github.com/doc/modules.html">Thrust API (Doxygen)</a></li>
+            <li><a title="Thrust API Doxygen" href="http://thrust.github.io/doc/modules.html">Thrust API (Doxygen)</a></li>
             <li><a title="Example Programs" href="http://github.com/thrust/thrust/tree/master/examples">Example Programs</a></li>
             <li><a title="GPU Computing Gems Article" href="http://github.com/downloads/thrust/thrust/Thrust:%20A%20Productivity-Oriented%20Library%20for%20CUDA.pdf">General Overview (PDF)</a></li>
             <li><a title="Thrust Wiki" href="http://github.com/thrust/thrust/wiki">Thrust Wiki</a></li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,7 +43,7 @@
       <li><a title="Quick Start Guide" href="http://github.com/thrust/thrust/wiki/Quick-Start-Guide">Get Started</a></li>
       <li><a title="Thrust Documentation" href="http://github.com/thrust/thrust/wiki/Documentation" class="submenu_title">Documentation</a>
         <ul class="submenu">
-            <li><a title="Thrust API Doxygen" href="http://thrust.github.io/doc/modules.html">Thrust API (Doxygen)</a></li>
+            <li><a title="Thrust API Doxygen" href="https://thrust.github.io/doc/modules.html">Thrust API (Doxygen)</a></li>
             <li><a title="Example Programs" href="http://github.com/thrust/thrust/tree/master/examples">Example Programs</a></li>
             <li><a title="GPU Computing Gems Article" href="http://github.com/downloads/thrust/thrust/Thrust:%20A%20Productivity-Oriented%20Library%20for%20CUDA.pdf">General Overview (PDF)</a></li>
             <li><a title="Thrust Wiki" href="http://github.com/thrust/thrust/wiki">Thrust Wiki</a></li>


### PR DESCRIPTION
This is a minimal fix for issues #7 and https://github.com/NVIDIA/thrust/issues/1497. This may be superseded by future changes to the documentation structure as it moves to https://nvidia.github.io/thrust/, but will fix the immediate problem for users referencing the old site.
