### PR TITLE
Fix "Get Thrust" download link to point to GitHub releases

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -68,7 +68,7 @@
       </li>
       {% endfor %}
       -->
-      <li><a title="Download latest Thrust source code" href="https://github.com/thrust/thrust/releases/download/1.8.1/thrust-1.8.1.zip">Get Thrust</a></li>
+      <li><a title="Download latest Thrust source code" href="https://github.com/NVIDIA/thrust/releases">Get Thrust</a></li>
 	</ul>
     
 


### PR DESCRIPTION
The current "Get Thrust" button points to a dead URL. This PR fixes it to point to GitHub releases.